### PR TITLE
Added special marks for failed tests

### DIFF
--- a/perftracker/templates/comparison_id.html
+++ b/perftracker/templates/comparison_id.html
@@ -244,7 +244,23 @@ $(document).ready(function() {
             title: {
             },
             tooltip: {
-                formatter: '{a}: {c}',
+                transitionDuration: 0,
+                formatter: function(params) {
+                    var s = params.seriesName + "<br>";
+                {% if s.chart_type == PTCmpChartType.XYLINE %}
+                    if (params.data.errors)
+                        s += params.data.value[0] + " : " + params.data.value[1] + "<br>"
+                             + params.data.errors + " iteration(s) failed";
+                    else
+                        s += params.data[0] + " : " + params.data[1];
+                {% else %}
+                    if (params.data.errors)
+                        s += params.data.value + "<br>" + params.data.errors + " iteration(s) failed";
+                    else
+                        s += params.data;
+                {% endif %}
+                    return s;
+                }
             },
             legend: {
                 data: {{ s.legends|safe }},
@@ -317,6 +333,9 @@ $(document).ready(function() {
               },
               {% endif %}
             {% endfor %}
+            {% if s.chart_type == PTCmpChartType.XYLINE %}
+               {name: 'Failed test', type: 'line', itemStyle: { color: '#000'}},
+            {% endif %}
             ]
           };
           chart.setOption(option);


### PR DESCRIPTION
Added special marks for failed tests (where status == FAILED or errors > 0)

Marks appear as black diamonds on XYChart, or as 'fail' label on BarChart.
Item tooltip contains number of failed iterations.
For XYChart legend contains a line for failed tests.